### PR TITLE
feat: add submodule index to rendered output

### DIFF
--- a/src/parsing/module.rs
+++ b/src/parsing/module.rs
@@ -16,7 +16,7 @@ pub struct ModuleDocumentation {
     pub docstring: Option<String>,
     pub functions: Vec<FunctionDocumentation>,
     pub classes: Vec<ClassDocumentation>,
-    pub sub_modules: Vec<ModuleReference>,
+    pub sub_modules: Option<Vec<PathBuf>>,
     pub exports: Option<Vec<String>>,
 }
 
@@ -25,6 +25,17 @@ pub struct ModuleReference {
     pub name: String,
     pub path: PathBuf,
 }
+
+// This one is the only gets done separately because it we can't deduce it from the file
+// contents themselves, we have to walk the fs for it, so we add a convenience
+// function so we can add that after the fact
+impl ModuleDocumentation {
+    pub fn with_sub_modules(&mut self, subs: Option<&Vec<PathBuf>>) -> &mut Self {
+        self.sub_modules = subs.cloned();
+        self
+    }
+}
+
 // just a conveneience function
 pub fn extract_module_documentation(
     input_module: &Mod,
@@ -153,7 +164,7 @@ fn extract_documentation_from_statements(
         docstring,
         functions: free_functions,
         classes: class_definitions,
-        sub_modules: Vec::new(),
+        sub_modules: None,
         exports,
     }
 }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -75,6 +75,24 @@ pub fn render_module(mod_doc: ModuleDocumentation) -> String {
         out.push('\n');
     }
 
+    if let Some(sub_modules) = &mod_doc.sub_modules {
+        out.push_str("\n## Submodules:\n\n");
+        for sub_mod in sub_modules {
+            let name = if sub_mod.ends_with("_index.md") {
+                sub_mod
+                    .parent()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or_default()
+            } else {
+                sub_mod
+                    .file_stem()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or_default()
+            };
+            out.push_str(&format!("- [{}]({})\n", &name, &sub_mod.display()));
+        }
+    }
+
     out
 }
 
@@ -142,8 +160,8 @@ fn render_function_docs(
     out.push('(');
     out.push_str(&render_args(fn_docs.args));
     out.push(')');
-    if let Some(return_annotaiton) = fn_docs.return_type {
-        out.push_str(&format!(" -> {}", render_expr(return_annotaiton)));
+    if let Some(return_annotation) = fn_docs.return_type {
+        out.push_str(&format!(" -> {}", render_expr(return_annotation)));
     }
     out.push('\n');
 

--- a/tests/rendered_full/test_pkg/_index.md
+++ b/tests/rendered_full/test_pkg/_index.md
@@ -3,3 +3,11 @@
 Root package initialization.
 
 This file marks the root as a Python package.
+
+## Submodules:
+
+- [_private](_private/_index.md)
+- [bar](bar.md)
+- [foo](foo.md)
+- [sub1](sub1/_index.md)
+- [syntax_error](syntax_error.md)

--- a/tests/rendered_full/test_pkg/_private/_index.md
+++ b/tests/rendered_full/test_pkg/_private/_index.md
@@ -8,3 +8,7 @@ This subpackage contains internal modules and functions intended for internal us
 
 - [calculate_secret_value](#test_pkg._private.calculate_secret_value)
 - [InternalHelper](#test_pkg._private.InternalHelper)
+
+## Submodules:
+
+- [internals](internals.md)

--- a/tests/rendered_full/test_pkg/sub1/_index.md
+++ b/tests/rendered_full/test_pkg/sub1/_index.md
@@ -3,3 +3,8 @@
 sub1 subpackage initialization.
 
 Marks sub1 as a package.
+
+## Submodules:
+
+- [mid](mid.md)
+- [sub2](sub2/_index.md)

--- a/tests/rendered_full/test_pkg/sub1/sub2/_index.md
+++ b/tests/rendered_full/test_pkg/sub1/sub2/_index.md
@@ -3,3 +3,8 @@
 sub2 subpackage initialization.
 
 Marks sub2 as a package.
+
+## Submodules:
+
+- [one](one.md)
+- [two](two.md)

--- a/tests/rendered_no_private/test_pkg/_index.md
+++ b/tests/rendered_no_private/test_pkg/_index.md
@@ -3,3 +3,10 @@
 Root package initialization.
 
 This file marks the root as a Python package.
+
+## Submodules:
+
+- [bar](bar.md)
+- [foo](foo.md)
+- [sub1](sub1/_index.md)
+- [syntax_error](syntax_error.md)

--- a/tests/rendered_no_private/test_pkg/sub1/_index.md
+++ b/tests/rendered_no_private/test_pkg/sub1/_index.md
@@ -3,3 +3,8 @@
 sub1 subpackage initialization.
 
 Marks sub1 as a package.
+
+## Submodules:
+
+- [mid](mid.md)
+- [sub2](sub2/_index.md)

--- a/tests/rendered_no_private/test_pkg/sub1/sub2/_index.md
+++ b/tests/rendered_no_private/test_pkg/sub1/sub2/_index.md
@@ -3,3 +3,8 @@
 sub2 subpackage initialization.
 
 Marks sub2 as a package.
+
+## Submodules:
+
+- [one](one.md)
+- [two](two.md)


### PR DESCRIPTION
This is mostly to make sure the rendered output is navigable when it get's rendered to a web page. Exactly how it looks and if it should be configurable we'll have to investigate more later. 

Some ideas for later:
- add a transparent option to just include the docs of sub modules in the parent
- option to disable adding these references to output.