### PR TITLE
chore: disable patch coverage

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -4,6 +4,7 @@ coverage:
   range: 85..100
   round: down
   precision: 1
+  patch: off
   status:
     # ref: https://docs.codecov.com/docs/commit-status
     project:


### PR DESCRIPTION
I find the patch coverage to be overly sensitive, especially with how flaky llvm-cov can be (some lines seem to be untouchable like in `src/cli.rs` I think for now we're good enough with general coverage. We can always re enable it again if we need to. 