### PR TITLE
fix: remove dbg statements and add pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,3 +27,10 @@ repos:
     rev: d0f10c617d701e29e5fbf153222a4e4120b994fa
     hooks:
       - id: commitlint
+  - repo: local
+    hooks:
+    - id: check-no-dbg
+      name: no dbg!
+      entry: bash -c 'rg --no-heading --line-number "dbg!" "$@" && echo "❌ dbg! found!" && exit 1 || exit 0'
+      language: system
+      files: \.rs$

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -274,13 +274,11 @@ pub fn walk_package(
         subs.extend(child_pkgs);
         subs.sort();
         subs.retain(|p| should_include(p, skip_private, &exclude));
-        dbg!(&subs);
         subs = subs
             .into_iter()
             .filter_map(|p| p.strip_prefix(sub_pkg).ok().map(|s| s.to_path_buf()))
             .map(|p| translate_filename(&p).to_path_buf())
             .collect();
-        dbg!(&subs);
         let _entry = sub_modules.insert(sub_pkg.clone(), subs);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,6 @@ pub fn render_docs(
     tracing::info!("indexing package at {}", &pkg_path.display());
     let pkg_index = walk_package(pkg_path, skip_private, exclude)?;
 
-    dbg!(&pkg_index);
     tracing::info!("Creating directories");
 
     for sub_pkg in pkg_index.package_paths {
@@ -77,7 +76,6 @@ pub fn render_docs(
                     }
                     tmp_docs
                 };
-                dbg!(&documentation.name, &documentation.sub_modules);
                 tracing::debug!("rendering documentation...");
                 let rendered = render_module(documentation);
                 let new_path = translate_filename(&full_path);


### PR DESCRIPTION
I forget to remove the `dbg!` statements a bit too often, so just add an inline pre commit hookds to check for them 