### PR TITLE
fix: check tree is clean before opening pr

### DIFF
--- a/justfile
+++ b/justfile
@@ -68,9 +68,10 @@ install-dev-tools:
 # Run all quality checks: fmt, lint, check, test
 ci: lint test
 
+# bit hacky but this should at least work across shells
+# checks if there is a pr open from the current branch and if not opens one for you
+# will only happen if lint and test pass and there are not uncommitted changes to tracked files
 pr: ci
-    # bit hacky but this should at least work across shells
-    # checks if there is a pr open from the current branch and if not opens one for you
-    # will only happen if lint and test pass
     gh pr list --head "$(git rev-parse --abbrev-ref HEAD)" --json author --jq ". == []" | grep -q "true"
+    git diff-index --quiet HEAD --
     gh pr create --web --fill-first


### PR DESCRIPTION
the previous just command only checked if the lints and tests passes but if you have that with uncommitted changes you'll open a PR against the wrong commit, basically just wasting CI time. With this change it is pretty much always safe to use `just pr` because it ownt open the PR until the tree is clean